### PR TITLE
[#12] design : 헤더 스타일 변경 / 글로벌 스타일 스크롤바 추가 / 로그인 페이지 헤더 제거

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -114,6 +114,11 @@ function Header() {
 export default Header;
 
 const HeaderLayout = styled.div<{ $isBorderBottom?: boolean; $isLoginPage?: boolean }>`
+  position: sticky;
+  z-index: 1;
+  top: 0;
+  background-color: ${({ theme }) => theme.Color.componentColor};
+
   display: flex;
   align-items: center;
   justify-content: ${(props) => (props.$isLoginPage ? "center" : "space-between")};
@@ -121,7 +126,7 @@ const HeaderLayout = styled.div<{ $isBorderBottom?: boolean; $isLoginPage?: bool
   width: 100%;
   height: 2.5rem;
 
-  padding: ${(props) => props.theme.Padding.default};
+  padding: ${({ theme }) => theme.Padding.default};
 
   ${(props) =>
     props.$isBorderBottom &&
@@ -138,7 +143,7 @@ const HeaderLeftBox = styled.div`
 
 const HeaderLogoSVG = styled(HeaderLogo)`
   cursor: pointer;
-  fill: ${(props) => props.theme.Color.mainColor};
+  fill: ${({ theme }) => theme.Color.mainColor};
   margin: 0 0 0 0.25rem;
 `;
 
@@ -156,5 +161,5 @@ const CartSVG = styled(Cart)`
 
 const HeaderTitle = styled.p`
   font-weight: 700;
-  font-size: ${(props) => props.theme.Fs.tagTitle};
+  font-size: ${({ theme }) => theme.Fs.tagTitle};
 `;

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -48,17 +48,17 @@ function Header() {
         </>
       );
 
-    case "login":
-      return (
-        <HeaderLayout $isLoginPage>
-          <HeaderLogoSVG onClick={handleTitleClick} />
-        </HeaderLayout>
-      );
+    // case "login":
+    //   return (
+    //     <HeaderLayout $isLoginPage>
+    //       <HeaderLogoSVG onClick={handleTitleClick} />
+    //     </HeaderLayout>
+    //   );
 
     case "search":
       return (
         <>
-          <HeaderLayout>
+          <HeaderLayout $isBorderBottom>
             <ListSVG onClick={handleListClick} />
             <HeaderLogoSVG onClick={handleTitleClick} />
             <CartSVG onClick={handleCartClick} />
@@ -70,7 +70,7 @@ function Header() {
     case "detail":
       return (
         <>
-          <HeaderLayout>
+          <HeaderLayout $isBorderBottom>
             <ListSVG onClick={handleListClick} />
             <HeaderLogoSVG onClick={handleTitleClick} />
             <CartSVG onClick={handleCartClick} />
@@ -91,7 +91,7 @@ function Header() {
 
     case "mypage":
       return (
-        <HeaderLayout>
+        <HeaderLayout $isBorderBottom>
           <HeaderLeftBox>
             <ArrowLeftSVG id="arrowLeft" onClick={handleArrowLeftClick} />
             <HeaderTitle>내 정보 관리</HeaderTitle>
@@ -101,7 +101,7 @@ function Header() {
 
     case "reservation":
       return (
-        <HeaderLayout>
+        <HeaderLayout $isBorderBottom>
           <HeaderLeftBox>
             <ArrowLeftSVG id="arrowLeft" onClick={handleArrowLeftClick} />
             <HeaderTitle>예약</HeaderTitle>
@@ -124,9 +124,8 @@ const HeaderLayout = styled.div<{ $isBorderBottom?: boolean; $isLoginPage?: bool
   justify-content: ${(props) => (props.$isLoginPage ? "center" : "space-between")};
 
   width: 100%;
-  height: 2.5rem;
 
-  padding: ${({ theme }) => theme.Padding.default};
+  padding: ${({ theme }) => theme.Padding.header};
 
   ${(props) =>
     props.$isBorderBottom &&

--- a/src/components/Header/Sidebar.tsx
+++ b/src/components/Header/Sidebar.tsx
@@ -48,6 +48,8 @@ function Sidebar({ isOpen, setIsOpen }: Props) {
 export default Sidebar;
 
 const SidebarLayout = styled.div<{ $isOpen: boolean }>`
+  z-index: 2;
+
   transition: all 0.75s ease;
 
   position: fixed;
@@ -70,7 +72,7 @@ const SidebarTopBox = styled.div`
   width: 100%;
   height: 13rem;
 
-  padding: ${({ theme }) => theme.Padding.default};
+  padding: ${({ theme }) => theme.Padding.header};
 
   display: flex;
   flex-direction: column;

--- a/src/components/Header/Sidebar.tsx
+++ b/src/components/Header/Sidebar.tsx
@@ -66,11 +66,11 @@ const SidebarLayout = styled.div<{ $isOpen: boolean }>`
 `;
 
 const SidebarTopBox = styled.div`
-  background-color: ${(props) => props.theme.Color.mainColor};
+  background-color: ${({ theme }) => theme.Color.mainColor};
   width: 100%;
   height: 13rem;
 
-  padding: ${(props) => props.theme.Padding.default};
+  padding: ${({ theme }) => theme.Padding.default};
 
   display: flex;
   flex-direction: column;
@@ -88,7 +88,7 @@ const ArrowUpSVG = styled(ArrowUp)`
 `;
 
 const TransparentArrowUpSVG = styled(ArrowUp)`
-  fill: ${(props) => props.theme.Color.mainColor};
+  fill: ${({ theme }) => theme.Color.mainColor};
 `;
 
 const HeaderLogoSVG = styled(HeaderLogo)`
@@ -100,7 +100,7 @@ const SidebarTopBoxText = styled.p`
   margin: 1rem 0 0 0;
 
   color: white;
-  font-size: ${(props) => props.theme.Fs.default};
+  font-size: ${({ theme }) => theme.Fs.default};
   font-weight: 400;
   text-align: center;
 `;
@@ -109,7 +109,7 @@ const SidebarTopLogoutBtnBox = styled.button`
   margin: 4rem 0 0 0;
 
   font-weight: 400;
-  font-size: ${(props) => props.theme.Fs.default};
+  font-size: ${({ theme }) => theme.Fs.default};
   color: white;
 
   display: flex;
@@ -130,7 +130,7 @@ const ArrowRightSVG = styled(ArrowRight)`
 `;
 
 const SidebarBottomBox = styled.div`
-  background-color: ${(props) => props.theme.Color.borderColor};
+  background-color: ${({ theme }) => theme.Color.borderColor};
 
   width: 100%;
   height: calc(100% - 13rem);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -19,6 +19,15 @@ export const GlobalStyle = createGlobalStyle`
       box-sizing: border-box;
       font-family: 'Noto Sans KR', sans-serif;
   }
+    
+  // hide scroll
+  * {
+    -ms-overflow-style: none; /* IE and Edge */
+    scrollbar-width: none; /* Firefox */
+    ::-webkit-scrollbar {
+      display: none; /* Chrome, Safari, Opera*/
+    }
+  }
 `;
 
 const theme = {
@@ -62,7 +71,9 @@ const theme = {
   Bs: {
     default: "3px 4px 16px 2px rgba(0, 0, 0, 0.06)",
   },
+
   Padding: {
+    header: "0.75rem 1.25rem 0.75rem 1.25rem",
     default: "0.5rem",
   },
 };

--- a/src/routes/MainStyleRoute.tsx
+++ b/src/routes/MainStyleRoute.tsx
@@ -20,4 +20,9 @@ const MainStyleRouteLayoutWrapper = styled.div`
 
 const MainStyleRouteLayout = styled.div`
   width: 375px;
+
+  border-left: ${({ theme }) => theme.Border.thickBorder};
+  border-right: ${({ theme }) => theme.Border.thickBorder};
+
+  box-shadow: ${({ theme }) => theme.Bs.default};
 `;


### PR DESCRIPTION
### ⛳️ Task

- [x] 화이팅하기
- [x] 글로벌 스타일 스크롤바 관련 속성 추가
  - 모든 페이지에서 스크롤바가 보이지 않습니다.
 - [x] MainStyleRoute border, box-shadow 추가
 - [x] 로그인 페이지 헤더 컴포넌트 렌더링 제거 (주석처리) 
 - [x] 메인페이지를 제외한 헤더 컴포넌트에 border-bottom 추가
 - [x] 기타 헤더, 사이드바 스타일 변경

### ✍️ Note

### 📸 Screenshot

### 📎 Reference

close #12 