### PR TITLE
[#58] feat : 검색 페이지 테스트케이스 추가 및 github-action localhost 테스트

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -59,9 +59,9 @@ export default defineConfig({
   ],
 
   /* Run your local dev server before starting the tests */
-  // webServer: {
-  //   command: 'npm run start',
-  //   url: 'http://127.0.0.1:3000',
-  //   reuseExistingServer: !process.env.CI,
-  // },
+  webServer: {
+    command: "npm run dev",
+    url: "http://localhost:5173",
+    reuseExistingServer: !process.env.CI,
+  },
 });

--- a/tests/searchPage.spec.ts
+++ b/tests/searchPage.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from "@playwright/test";
+
+test("검색 페이지 이용하기", async ({ page }) => {
+  await page.locator("body").click();
+  await page.goto("http://localhost:5173/search");
+  await page.getByPlaceholder("숙소명을 입력하세요").click();
+  await page.getByPlaceholder("숙소명을 입력하세요").fill("플로팅웨일 설악도적폭포스테이");
+  await page.getByPlaceholder("숙소명을 입력하세요").press("Enter");
+  await page.getByText("플로팅웨일 설악도적폭포스테이").click();
+  await page.getByRole("heading", { name: "플로팅웨일 설악도적폭포스테이" }).click();
+
+  const title = page.getByRole("heading", { name: "플로팅웨일 설악도적폭포스테이" });
+
+  await expect(title).toBeVisible;
+});
+
+test("검색 결과가 존재하지 않는 경우", async ({ page }) => {
+  await page.goto("http://localhost:5173/search");
+  await page.getByPlaceholder("숙소명을 입력하세요").click();
+  await page.getByPlaceholder("숙소명을 입력하세요").fill("asdfasdfasdf");
+  await page.getByPlaceholder("숙소명을 입력하세요").press("Enter");
+
+  const noResult = page.getByText("검색 결과가 없습니다");
+
+  await expect(noResult).toBeVisible;
+});


### PR DESCRIPTION
### ⛳️ Task

- [x] 화이팅하기
- [x] 검색페이지 테스트케이스 추가

### ✍️ Note

npx playwright codegen -> npm run dev로 로컬 서버를 띄워놓은 뒤 테스트 코드 자동 생성을 위해 사용할 수 있습니다.

playwright.config.ts 에서 npm run dev 명령어를 추가하여
작성해놓은 테스트 파일을 npx playwright test 를 통해 실행하고 테스트 결과를 확인할 수 있습니다.
(테스트 결과는 파일로도 생기고 CLI 창에 로컬호스트 주소 또한 반환합니다.)

참고 링크
https://velog.io/@sosoyim/e2e-%ED%85%8C%EC%8A%A4%ED%8A%B8-%EB%8F%84%EA%B5%AC%EC%9D%B8-Playwright-%EC%84%A0%ED%83%9D-%EC%9D%B4%EC%9C%A0

https://ui.toast.com/posts/ko_20210818

https://playwright.dev/docs/test-webserver

### 📸 Screenshot

### 📎 Reference

close #58 