### PR TITLE
feat : 로그인 성공 실패 테스트 추가

### DIFF
--- a/tests/loginPage.spec.ts
+++ b/tests/loginPage.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from "@playwright/test";
+
+test("로그인 성공 테스트", async ({ page }) => {
+  await page.goto("http://localhost:5173/");
+  await page.locator("path:nth-child(2)").click();
+  await page.getByRole("button", { name: "로그인" }).click();
+  await page.getByPlaceholder("이메일을 입력해주세요").click();
+  await page.getByPlaceholder("이메일을 입력해주세요").fill("leeyuwk54@gmail.com");
+  await page.getByPlaceholder("이메일을 입력해주세요").press("Tab");
+  await page.getByPlaceholder("비밀번호를 입력해주세요").fill("dlduddnr1!");
+  await page.getByRole("button", { name: "로그인" }).click();
+  await page.locator("path:nth-child(2)").click();
+
+  const loginTitle = page.getByText("leeyuwk54@gmail.com");
+
+  await expect(loginTitle).toContainText("leeyuwk54@gmail.com");
+});
+
+test("로그인 실패 테스트", async ({ page }) => {
+  await page.goto("http://localhost:5173/");
+  await page.locator(".sc-flMqbI").click();
+  await page.getByRole("button", { name: "로그인" }).click();
+  await page.getByPlaceholder("이메일을 입력해주세요").click();
+  await page.getByPlaceholder("이메일을 입력해주세요").fill("failtest");
+  await page.getByPlaceholder("이메일을 입력해주세요").press("Tab");
+  await page.getByPlaceholder("비밀번호를 입력해주세요").fill("failtest");
+  await page.getByRole("button", { name: "로그인" }).click();
+
+  const loginFailAlert = page.getByText("로그인 실패");
+
+  await expect(loginFailAlert).toContainText("로그인 실패");
+});


### PR DESCRIPTION
### ⛳️ Task

- [x] 화이팅하기
- [x] 로그인 성공 실패 테스트 추가

### ✍️ Note

각 행동 이후, 페이지가 넘어가지 않는 것처럼 보이지만
playwright 를 이용한 사용자의 행동 (click 등)을 코드로 작성하지 않으면
비동기 API와 상관없이 화면을 정지시키는 것 같습니다. (npx playwright test --ui 내에서)

클릭하는 행동 등을 await을 이용해 촉발시키면 이동한 페이지의 화면을 정상적으로 보여줍니다.

### 📸 Screenshot

### 📎 Reference

close #64 
